### PR TITLE
fix(Editor): prevent freezing when closing window on add - fixes #7

### DIFF
--- a/Editor/PackageImporter.cs
+++ b/Editor/PackageImporter.cs
@@ -187,6 +187,28 @@ namespace Tilia.Utilities
             GUILayout.Space(8);
         }
 
+        private void OnDestroy()
+        {
+            if (getWebDataRoutine != null)
+            {
+                EditorCoroutineUtility.StopCoroutine(getWebDataRoutine);
+            }
+
+            if (addRequest != null)
+            {
+                EditorApplication.update -= HandlePackageAddRequest;
+                addRequest = null;
+            }
+
+#if UNITY_2021_2_OR_NEWER
+            if(addAndRemoveRequest != null)
+            {
+                EditorApplication.update -= HandlePackageAddAndRemoveRequest;
+                addAndRemoveRequest = null;
+            }
+#endif
+        }
+
         private void AddPackage(string packageName)
         {
             addRequest = Client.Add(packageName);


### PR DESCRIPTION
A check in the OnDestroy now cleans up the thread state to ensure
old threads aren't still running after the window has been closed.