### PR TITLE
fix(PackageImporter): support Unity version 2018+

### DIFF
--- a/Editor/PackageImporter.cs
+++ b/Editor/PackageImporter.cs
@@ -389,7 +389,11 @@ namespace Tilia.Utilities
 
         private static void GetInstalledPackages()
         {
+#if UNITY_2019_3_OR_NEWER
             installedPackagesRequest = Client.List(false, true);
+#else
+            installedPackagesRequest = Client.List(false);
+#endif
             EditorApplication.update += HandleInstalledPackagesRequest;
         }
 

--- a/Editor/PackageImporter.cs
+++ b/Editor/PackageImporter.cs
@@ -290,6 +290,7 @@ namespace Tilia.Utilities
                 // Request and wait for the desired page.
                 yield return webRequest.SendWebRequest();
 
+#if UNITY_2020_1_OR_NEWER
                 switch (webRequest.result)
                 {
                     case UnityWebRequest.Result.ConnectionError:
@@ -303,6 +304,20 @@ namespace Tilia.Utilities
                         ParseRawData(webRequest.downloadHandler.text);
                         break;
                 }
+#else
+                if (webRequest.isNetworkError)
+                {
+                    Debug.LogError("Error: " + webRequest.error);
+                }
+                else if (webRequest.isHttpError)
+                {
+                    Debug.LogError("HTTP Error: " + webRequest.error);
+                }
+                else
+                {
+                    ParseRawData(webRequest.downloadHandler.text);
+                }
+#endif
             }
 
             getWebDataRoutine = null;

--- a/Editor/VRTK.Tilia.Package.Importer.Editor.asmdef
+++ b/Editor/VRTK.Tilia.Package.Importer.Editor.asmdef
@@ -2,7 +2,7 @@
     "name": "VRTK.Tilia.Package.Importer.Editor",
     "rootNamespace": "",
     "references": [
-        "GUID:478a2357cc57436488a56e564b08d223"
+        "Unity.EditorCoroutines.Editor"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
UnityWebRequest.result only works in Unity 2020.1 and above. Previous versions
uses isNetworkError and isHttpError to differentiate the kind of error received.